### PR TITLE
Auto-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Release Creation
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # get part of the tag after the `v`
+      - name: Extract tag version number
+        id: get-version
+        run: echo "version-without-v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Get Module JSON
+        id: set_var
+        run: |
+          echo "PACKAGE_JSON=$(jq -c . < module.json)" >> $GITHUB_OUTPUT
+
+      - name: Get Module Title
+        id: title
+        run: echo "title=${{ fromJson(steps.set_var.outputs.PACKAGE_JSON).title }}" >> "$GITHUB_OUTPUT"
+
+      # Substitute the Manifest and Download URLs in the `module.json`.
+      - name: Substitute Manifest and Download Links For Versioned Ones
+        id: sub_manifest_link_version
+        uses: devops-actions/variable-substitution@v1.2
+        with:
+          files: module.json
+        env:
+          version: ${{ steps.get-version.outputs.version-without-v }}
+          manifest: https://github.com/${{ github.repository }}/releases/latest/download/module.json
+          download: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/module.zip
+
+      # Create a folder containing all the module stuff and zip it for the release
+      - name: Create Zip
+        run: zip -r9 ./module.zip module.json artwork/ packs/ README.md LICENSE
+
+      - name: Update Release with Files
+        id: create_version_release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          name: ${{ steps.get-version.outputs.version-without-v }}
+          body: ${{ steps.changelog.outputs.release-notes }}
+          artifacts: './module.json, ./module.zip'
+
+      - name: Publish to FoundryVTT
+        uses: cs96and/FoundryVTT-release-package@v1.0.2
+        if: ${{ !github.event.release.prerelease && env.PACKAGE_TOKEN }}
+        env:
+          PACKAGE_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+        with:
+          package-token: ${{ env.PACKAGE_TOKEN }}
+          manifest-url: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/module.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # get part of the tag after the `v`
       - name: Extract tag version number
         id: get-version
-        run: echo "version-without-v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Get Module JSON
         id: set_var
@@ -34,7 +33,7 @@ jobs:
         with:
           files: module.json
         env:
-          version: ${{ steps.get-version.outputs.version-without-v }}
+          version: ${{ steps.get-version.outputs.version }}
           manifest: https://github.com/${{ github.repository }}/releases/latest/download/module.json
           download: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/module.zip
 
@@ -50,7 +49,7 @@ jobs:
           allowUpdates: true
           omitDraftDuringUpdate: true
           omitPrereleaseDuringUpdate: true
-          name: ${{ steps.get-version.outputs.version-without-v }}
+          name: ${{ steps.get-version.outputs.version }}
           body: ${{ steps.changelog.outputs.release-notes }}
           artifacts: './module.json, ./module.zip'
 


### PR DESCRIPTION
An automatic script that creates a properly formatted and zipped up files when you make a new release. You simply go create a new release, no need for file uploads, and let the script handle it for you.

Additionally, you may get the API key from the Foundry module page and put it in your [GitHub secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) under `PACKAGE_TOKEN`. It will auto-add the new version to your Foundry listing.